### PR TITLE
Version 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.2 (4/6/2020)
+- Improve `AuthBloc`:
+  - Do not await AuthStorage twice in constructor
+  - Add `logOut` function
+  - Better docs
+
 ## 0.2.1 (4/4/2020)
 - Added bookmarks endpoint with corresponding MockBookmarks class
 - Renamed `bookmarkStatus` to `bookmark`, `unbookmarkStatus` to `unbookmark` to closer match the Mastodon docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.1 (4/4/2020)
+- Added bookmarks endpoint with corresponding MockBookmarks class
+- Renamed `bookmarkStatus` to `bookmark`, `unbookmarkStatus` to `unbookmark` to closer match the Mastodon docs.
+- Moved `bookmark` and `unbookmark` methods to bookmarks endpoint
+
 ## 0.2.0 (4/2/2020)
 - Major refactor for `AuthBloc`
   - Introduce `NullInterceptorSink<T>` class to ensure that data being added to a sink cannot be null. Update `codeSink` to use the `NullInterceptorSink`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.2.0 (4/2/2020)
+- Major refactor for `AuthBloc`
+  - Introduce `NullInterceptorSink<T>` class to ensure that data being added to a sink cannot be null. Update `codeSink` to use the `NullInterceptorSink`.
+  - Make sure we do not call `_handleCode` until we have an authenticated application
+  - Introduce `_initialized` Completer, `initialized` Future, and `hasAccount` bool check
+  - Update `_registerApplication` with a null check/error throw
+  - Update `_handleCode` to take an `AuthenticatedApplication` as well as a code
+  - Better error handling
+  - Updated documentation
+- Removed deprecated example code. Updated code coming soon.
+
 ## 0.1.5 (3/19/2020)
 - Add missing `text` property to `Status`
 

--- a/README.md
+++ b/README.md
@@ -12,38 +12,6 @@ This package is in development. Use in production at your own risk. That said, d
 
 Create an issue, back it with a PR, and tag an active contributor.
 
-## Mock Client
+## Example
 
-```dart
-import 'package:mastodon_dart/mastodon_dart.dart';
-
-main() async {
-  final mock = MockMastodon();
-
-  /// Hit the endpoints with blank parameters
-  mock.account("").then((a) => print(
-      [a, a.id, a.username, a.avatar, a.followersCount, a.followingCount]));
-
-  /// Get mock data classes for building UIs
-  /// [Instance of 'Account', 78056791, onegerbal4511, https://randomuser.me/api/portraits/men/64.jpg, 861, 34]
-}
-```
-
-## Auth'd Client
-
-```dart
-import 'package:mastodon_dart/mastodon_dart.dart';
-
-main() async {
-  final mastodon = Mastodon()
-    ..baseUrl = Uri.parse("https://mastodon.technology")
-    ..key = "my_awesome_oauth2_key";
-
-  final verify = await mastodon.verifyAppCredentials();
-
-  print([verify.name, verify.website]);
-
-  /// Our oauth2 key is correct! Lets make some real network calls.
-  /// [oauth2_client_name, https://oauth2_website.com]
-}
-```
+Updated example code coming soon

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,13 +4,5 @@ import 'package:mastodon_dart/mastodon_dart.dart';
 import 'package:web_socket_channel/io.dart';
 
 main() async {
-  final baseUrl = Uri.parse(Platform.environment["BASE_URL"]);
-  final token = Platform.environment["TOKEN"];
-
-  final mastodon = Mastodon(
-    baseUrl,
-    websocketFactory: (uri) => IOWebSocketChannel.connect(uri),
-  )..token = token;
-
-  mastodon.publicTimelineStream().listen(print);
+  // Updated example coming soon
 }

--- a/lib/mock/endpoints/bookmarks.dart
+++ b/lib/mock/endpoints/bookmarks.dart
@@ -1,0 +1,16 @@
+import 'package:mastodon_dart/mastodon_dart.dart';
+
+class MockBookmarks {
+  /// GET /api/v1/bookmarks
+  ///
+  /// TODO: implement link headers for pagination
+  /// shall we return prepopulated Futures for next/prev page?
+  Future<List<Status>> bookmarks({int limit = 40}) =>
+      Future.value(List.generate(limit, (_) => Status.mock()));
+
+  /// POST /api/v1/statuses/:id/bookmark
+  Future<Status> bookmark(String id) => Future.value(Status.mock());
+
+  /// POST /api/v1/statuses/:id/unbookmark
+  Future<Status> unbookmark(String id) => Future.value(Status.mock());
+}

--- a/lib/src/bloc/auth.dart
+++ b/lib/src/bloc/auth.dart
@@ -24,11 +24,17 @@ class NullInterceptorSink<T> extends DelegatingStreamSink<T> {
 /// is authenticated, the user can navigate to the browser via the [_uri]. When the user returns to the application with
 /// their auth code, user authentication will be performed with that code.
 class AuthBloc {
+  /// Handles the storing, retrieving, and deleting of the auth code
   final AuthStorageDelegate storage;
+  /// A Mastodon instance
   final Mastodon mastodon;
+  /// The Uri used to navigate the user to the browser for authentication
   final Uri website;
+  /// Can be user-provided, defaults to "urn:ietf:wg:oauth:2.0:oob"
   final String redirectUris;
+  /// The name of the application using the Mastodon API
   final String clientName;
+  /// Mastodon API scopes; can be user defined, defaults to "write", "read", "follow", "push"
   final List<String> scopes;
 
   AuthBloc(
@@ -36,7 +42,7 @@ class AuthBloc {
     this.website, {
     this.storage,
     this.redirectUris = "urn:ietf:wg:oauth:2.0:oob",
-    this.clientName = "mastodon-dart",
+    this.clientName = "mastodon_dart",
     this.scopes = const ["write", "read", "follow", "push"],
   }) {
     /// When the bloc is instantiated it will check for a stored auth token.
@@ -153,9 +159,10 @@ class AuthBloc {
     }
   }
 
+  /// Handles logging the user out. Deletes the stored auth token, wipes the values
+  /// from the code, token, and account streams
   Future<void> logOut() async {
     storage.deleteToken();
-    //_uri.value = null;
     _code.value = null;
     _token.value = null;
     _account.value = null;
@@ -176,7 +183,7 @@ class AuthBloc {
 }
 
 /// A simple storage driver interface that allows
-/// fetching and saving of a [token] as a string
+/// fetching, saving, and deleting of a [token] as a String
 abstract class AuthStorageDelegate {
   Future<void> saveToken(String token);
   Future<void> deleteToken();

--- a/lib/src/bloc/auth.dart
+++ b/lib/src/bloc/auth.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'package:mastodon_dart/src/authentication.dart';
 import 'package:mastodon_dart/src/data/account.dart';
 import 'package:mastodon_dart/src/data/application.dart';
 import 'package:mastodon_dart/src/mastodon.dart';

--- a/lib/src/endpoints/bookmarks.dart
+++ b/lib/src/endpoints/bookmarks.dart
@@ -1,0 +1,53 @@
+import '../library.dart';
+import '../../mock/endpoints/bookmarks.dart';
+
+mixin Bookmarks on Authentication, Utilities implements MockBookmarks {
+  /// GET /api/v1/bookmarks
+  ///
+  /// - authenticated (requires user)
+  /// - read read:favourites
+  Future<List<Status>> bookmarks({int limit = 40}) async {
+    final response = await request(
+      Method.get,
+      "/api/v1/bookmarks",
+      authenticated: true,
+      payload: {
+        "limit": limit.toString(),
+      },
+    );
+
+    final body = List<Map>.from(json.decode(response.body));
+
+    /// TODO: implement link headers for pagination
+
+    return body.map((m) => Status.fromJson(m)).toList();
+  }
+
+  /// POST /api/v1/statuses/:id/bookmark
+  ///
+  /// - authenticated
+  /// - write write:bookmarks
+  Future<Status> bookmark(String id) async {
+    final response = await request(
+      Method.post,
+      "/api/v1/statuses/$id/bookmark",
+      authenticated: true,
+    );
+
+    return Status.fromJson(json.decode(response.body));
+  }
+
+  /// POST /api/v1/statuses/:id/unbookmark
+  ///
+  /// - authenticated
+  /// - write write:bookmarks
+  Future<Status> unbookmark(String id) async {
+    final response = await request(
+      Method.post,
+      "/api/v1/statuses/$id/unbookmark",
+      authenticated: true,
+    );
+
+    return Status.fromJson(json.decode(response.body));
+  }
+}

--- a/lib/src/endpoints/statuses.dart
+++ b/lib/src/endpoints/statuses.dart
@@ -224,32 +224,4 @@ mixin Statuses on Authentication, Utilities implements MockStatuses {
 
     return Status.fromJson(json.decode(response.body));
   }
-
-  /// POST /api/v1/statuses/:id/bookmark
-  ///
-  /// - authenticated
-  /// - write write:bookmarks
-  Future<Status> bookmarkStatus(String id) async {
-    final response = await request(
-      Method.post,
-      "/api/v1/statuses/$id/bookmark",
-      authenticated: true,
-    );
-
-    return Status.fromJson(json.decode(response.body));
-  }
-
-  /// POST /api/v1/statuses/:id/unbookmark
-  ///
-  /// - authenticated
-  /// - write write:bookmarks
-  Future<Status> unbookmarkStatus(String id) async {
-    final response = await request(
-      Method.post,
-      "/api/v1/statuses/$id/unbookmark",
-      authenticated: true,
-    );
-
-    return Status.fromJson(json.decode(response.body));
-  }
 }

--- a/lib/src/mastodon.dart
+++ b/lib/src/mastodon.dart
@@ -5,6 +5,7 @@ import 'validators.dart';
 import 'endpoints/accounts.dart';
 import 'endpoints/apps.dart';
 import 'endpoints/blocks.dart';
+import 'endpoints/bookmarks.dart';
 import 'endpoints/custom_emojis.dart';
 import 'endpoints/domain_blocks.dart';
 import 'endpoints/endorsements.dart';
@@ -32,6 +33,7 @@ class _Rest = _Base
         Accounts,
         Apps,
         Blocks,
+        Bookmarks,
         CustomEmojis,
         DomainBlocks,
         Endorsements,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mastodon_dart
 description: The official Dart library for accessing the Mastodon API. Use in conjunction with mastodon_flutter to build a Flutter Mastodon app.
-version: 0.2.1
+version: 0.2.2
 homepage: https://github.com/lukepighetti/mastodon_dart
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mastodon_dart
 description: The official Dart library for accessing the Mastodon API. Use in conjunction with mastodon_flutter to build a Flutter Mastodon app.
-version: 0.2.0
+version: 0.2.1
 homepage: https://github.com/lukepighetti/mastodon_dart
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mastodon_dart
 description: The official Dart library for accessing the Mastodon API. Use in conjunction with mastodon_flutter to build a Flutter Mastodon app.
-version: 0.1.5
+version: 0.2.0
 homepage: https://github.com/lukepighetti/mastodon_dart
 
 environment:
@@ -14,5 +14,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.8.0
-  json_serializable: ^3.2.5
+  json_serializable: ^3.3.0
+  stack_trace: ^1.9.3
   test: ^1.14.2


### PR DESCRIPTION
Copypasta from changelog:

## 0.2.2 (4/6/2020)
- Improve `AuthBloc`:
  - Do not await AuthStorage twice in constructor
  - Add `logOut` function
  - Better docs

## 0.2.1 (4/4/2020)
- Added bookmarks endpoint with corresponding MockBookmarks class
- Renamed `bookmarkStatus` to `bookmark`, `unbookmarkStatus` to `unbookmark` to closer match the Mastodon docs.
- Moved `bookmark` and `unbookmark` methods to bookmarks endpoint

## 0.2.0 (4/2/2020)
- Major refactor for `AuthBloc`
  - Introduce `NullInterceptorSink<T>` class to ensure that data being added to a sink cannot be null. Update `codeSink` to use the `NullInterceptorSink`.
  - Make sure we do not call `_handleCode` until we have an authenticated application
  - Introduce `_initialized` Completer, `initialized` Future, and `hasAccount` bool check
  - Update `_registerApplication` with a null check/error throw
  - Update `_handleCode` to take an `AuthenticatedApplication` as well as a code
  - Better error handling
  - Updated documentation
- Removed deprecated example code. Updated code coming soon.