### PR TITLE
Move vapid_key to AuthenticatedApplication

### DIFF
--- a/lib/src/models/application.dart
+++ b/lib/src/models/application.dart
@@ -17,13 +17,9 @@ class Application {
 
   final Uri? website;
 
-  /// Used for Push Streaming API. Returned with POST /api/v1/apps
-  final String vapidKey;
-
   Application({
     required this.name,
     required this.website,
-    required this.vapidKey,
   });
 
   factory Application.fromJson(Map<String, dynamic> json) =>
@@ -43,13 +39,16 @@ class AuthenticatedApplication extends Application {
   /// The clientSecret associated with your application
   final String clientSecret;
 
+  /// Used for Push Streaming API. Returned with POST /api/v1/apps
+  final String vapidKey;
+
   AuthenticatedApplication({
     required String name,
     required Uri? website,
-    required String vapidKey,
     required this.clientId,
     required this.clientSecret,
-  }) : super(name: name, website: website, vapidKey: vapidKey);
+    required this.vapidKey,
+  }) : super(name: name, website: website);
 
   factory AuthenticatedApplication.fromJson(Map<String, dynamic> json) =>
       _$AuthenticatedApplicationFromJson(json);

--- a/lib/src/models/application.g.dart
+++ b/lib/src/models/application.g.dart
@@ -10,7 +10,6 @@ Application _$ApplicationFromJson(Map<String, dynamic> json) => Application(
       name: json['name'] as String,
       website:
           json['website'] == null ? null : Uri.parse(json['website'] as String),
-      vapidKey: json['vapid_key'] as String,
     );
 
 AuthenticatedApplication _$AuthenticatedApplicationFromJson(
@@ -19,7 +18,7 @@ AuthenticatedApplication _$AuthenticatedApplicationFromJson(
       name: json['name'] as String,
       website:
           json['website'] == null ? null : Uri.parse(json['website'] as String),
-      vapidKey: json['vapid_key'] as String,
       clientId: json['client_id'] as String,
       clientSecret: json['client_secret'] as String,
+      vapidKey: json['vapid_key'] as String,
     );


### PR DESCRIPTION
The [`application` value on a `status`](https://docs.joinmastodon.org/entities/Status/#application) only includes `name` and `website`. This failed to parse as the `Application` class required `vapidKey`. This change moves `vapidKey` to `AuthenticatedApplication`.