### PR TITLE
Stop requiring websocketFactory

### DIFF
--- a/lib/src/authentication.dart
+++ b/lib/src/authentication.dart
@@ -7,9 +7,9 @@ class Authentication {
   final Uri baseUrl;
 
   /// A (WebSocketChannel)[https://api.flutter.dev/flutter/dart-html/WebSocket-class.html] to receive data sent on a WebSocket
-  final WebSocketFactory websocketFactory;
+  final WebSocketFactory? websocketFactory;
 
-  Authentication(this.baseUrl, {required this.websocketFactory});
+  Authentication(this.baseUrl, {this.websocketFactory});
 
   /// Used to navigate the user to the token url for the given Mastodon instance
   Uri get tokenUrl => baseUrl.replace(path: "/oauth/token");

--- a/lib/src/websockets/websockets.dart
+++ b/lib/src/websockets/websockets.dart
@@ -18,7 +18,11 @@ mixin Websockets on Authentication {
       }..removeWhere((_, value) => value == null),
     );
 
-    return websocketFactory(uri);
+    if (websocketFactory == null) {
+      throw Exception("websocketFactory is not set");
+    }
+
+    return websocketFactory!(uri);
   }
 
   /// https://docs.joinmastodon.org/api/streaming/#websocket


### PR DESCRIPTION
Avoid having to instantiate with a websocketFactory when only using the rest API.

Old:
```dart
Mastodon(
    website,
    websocketFactory: (Uri uri) {
      throw UnimplementedError();
    },
  );
```

New:
```dart
Mastodon.(Uri.parse('https://mastodon.social'));
```

Alternative to https://github.com/lukepighetti/mastodon_dart/pull/46