### PR TITLE
Add rest constructor

### DIFF
--- a/lib/src/authentication.dart
+++ b/lib/src/authentication.dart
@@ -11,6 +11,12 @@ class Authentication {
 
   Authentication(this.baseUrl, {required this.websocketFactory});
 
+  Authentication.rest(baseUrl)
+      : this(
+          baseUrl,
+          websocketFactory: (Uri uri) => throw UnimplementedError(),
+        );
+
   /// Used to navigate the user to the token url for the given Mastodon instance
   Uri get tokenUrl => baseUrl.replace(path: "/oauth/token");
 


### PR DESCRIPTION
Adds named constructor to instantiate without websocket.

```dart
Mastodon.rest(Uri.parse('https://mastodon.social'));
```

Alternative to https://github.com/lukepighetti/mastodon_dart/pull/45