### PR TITLE
Add files support

### DIFF
--- a/lib/src/endpoints/media_attachments.dart
+++ b/lib/src/endpoints/media_attachments.dart
@@ -5,20 +5,22 @@ import '../models/attachment.dart';
 import '../utilities.dart';
 
 mixin MediaAttachments on Authentication, Utilities {
-  /// POST /api/v1/media
+  /// POST /api/v2/media
   ///
   /// - authenticated (requires user)
   /// - write write:media
-  Future<Attachment> uploadAttachment(dynamic file,
+  Future<Attachment> uploadAttachment(String file,
       {String? description, Object? focus}) async {
     final response = await request(
       Method.post,
-      "/api/v1/media",
+      "/api/v2/media",
       authenticated: true,
       payload: {
-        "file": file,
         "description": description,
         "focus": focus,
+      },
+      files: {
+        "file": file,
       },
     );
 

--- a/lib/src/endpoints/statuses.dart
+++ b/lib/src/endpoints/statuses.dart
@@ -97,6 +97,9 @@ mixin Statuses on Authentication, Utilities {
 
   /// POST /api/v1/statuses
   ///
+  /// Currently only supports a single media attachment.
+  ///   https://github.com/dart-lang/http/issues/47
+  ///
   /// - authenticated
   /// - write write:statuses
   Future<Status> publishStatus({
@@ -110,6 +113,7 @@ mixin Statuses on Authentication, Utilities {
     dynamic language,
   }) async {
     assert(status != null || mediaIds.isNotEmpty);
+    assert(mediaIds.length < 2);
 
     final response = await request(
       Method.post,
@@ -118,7 +122,7 @@ mixin Statuses on Authentication, Utilities {
       payload: {
         "status": status,
         "in_reply_to_id": inReplyToId,
-        "media_ids": mediaIds,
+        "media_ids[]": mediaIds.isEmpty ? null : mediaIds.first,
         "sensitive": "$sensitive",
         "visibility": visibility?.toString().split(".").last,
         "scheduled_at": scheduledAt?.toIso8601String(),


### PR DESCRIPTION
- Updates `uploadAttachment` to api `v2`
- Limit `publishStatus` to a single `mediaIds` value as [`http` doesn't support list values](https://github.com/dart-lang/http/issues/47)
- Added `MultipartRequest` files support to `post` methods

Validated with:

```dart
import 'package:mastodon_dart/mastodon_dart.dart';

const bearerToken = '';
final website = Uri.parse('https://mstdn.party');

void main() async {
  var client = Mastodon(website);
  client.token = bearerToken;

  var attachment1 = await client.uploadAttachment(
    'cat.jpg',
    description: 'cat',
  );
  print('a1 ${attachment1.id}');

  // var attachment2 = await client.uploadAttachment('cat.jpg');
  // print('a2 ${attachment2.id}');

  var response = await client.publishStatus(
    status: 'Testing with media',
    mediaIds: [attachment1.id],
  );
  print('s1 ${response.id}');

  var response2 = await client.publishStatus(status: 'Testing without media');
  print('s2 ${response2.id}');
}

```