### PR TITLE
Handle malformed Card#authorUrl parsing

### DIFF
--- a/lib/src/models/card.dart
+++ b/lib/src/models/card.dart
@@ -3,7 +3,7 @@ import 'package:json_annotation/json_annotation.dart';
 part 'card.g.dart';
 
 /// Represents a rich preview card that is generated using OpenGraph tags from a URL.
-/// https://docs.joinmastodon.org/entities/card/
+/// https://docs.joinmastodon.org/entities/PreviewCard/
 
 @JsonSerializable()
 class Card {
@@ -27,6 +27,7 @@ class Card {
   final String? authorName;
 
   /// A link to the author of the original resource
+  @JsonKey(fromJson: _safeUriParse)
   final Uri? authorUrl;
 
   /// The provider of the original resource
@@ -50,6 +51,9 @@ class Card {
   /// Used for photo embeds, instead of custom [html]
   final Uri embedUrl;
 
+  /// A hash computed by the BlurHash algorithm, for generating colorful preview thumbnails when media has not been downloaded yet.
+  final String? blurhash;
+
   Card({
     required this.url,
     required this.title,
@@ -64,9 +68,12 @@ class Card {
     required this.width,
     required this.height,
     required this.embedUrl,
+    required this.blurhash,
   });
 
   factory Card.fromJson(Map<String, dynamic> json) => _$CardFromJson(json);
+
+  static Uri? _safeUriParse(String url) => Uri.tryParse(url);
 }
 
 enum CardType { link, photo, video, rich }

--- a/lib/src/models/card.g.dart
+++ b/lib/src/models/card.g.dart
@@ -13,9 +13,7 @@ Card _$CardFromJson(Map<String, dynamic> json) => Card(
       image: json['image'] == null ? null : Uri.parse(json['image'] as String),
       type: $enumDecode(_$CardTypeEnumMap, json['type']),
       authorName: json['author_name'] as String?,
-      authorUrl: json['author_url'] == null
-          ? null
-          : Uri.parse(json['author_url'] as String),
+      authorUrl: Card._safeUriParse(json['author_url'] as String),
       providerName: json['provider_name'] as String?,
       providerUrl: json['provider_url'] == null
           ? null
@@ -24,6 +22,7 @@ Card _$CardFromJson(Map<String, dynamic> json) => Card(
       width: json['width'] as int?,
       height: json['height'] as int?,
       embedUrl: Uri.parse(json['embed_url'] as String),
+      blurhash: json['blurhash'] as String?,
     );
 
 const _$CardTypeEnumMap = {

--- a/lib/src/models/card.g.dart
+++ b/lib/src/models/card.g.dart
@@ -39,6 +39,7 @@ Map<String, dynamic> _$CardToJson(Card instance) => <String, dynamic>{
       'height': instance.height,
       'image': instance.image?.toString(),
       'embed_url': instance.embedUrl.toString(),
+      'blurhash': instance.blurhash,
     };
 
 const _$CardTypeEnumMap = {


### PR DESCRIPTION
I ran across https://mastodon.social/@GIbiz/109626791400616879 which returns a malformed `author_url` value.

```
"author_url": "[\"https://www.gamesindustry.biz/authors/brendan-sinclair\", \"https://twitter.com/BrendanSinclair\"]",
```