### PR TITLE
Make previewUrl nullable

### DIFF
--- a/lib/src/models/attachment.dart
+++ b/lib/src/models/attachment.dart
@@ -24,7 +24,7 @@ class Attachment {
   final Uri url;
 
   /// The location of a scaled-down preview of the attachment
-  final Uri previewUrl;
+  final Uri? previewUrl;
 
   /// The location of the full-size original attachment on the remote website
 

--- a/lib/src/models/attachment.g.dart
+++ b/lib/src/models/attachment.g.dart
@@ -13,7 +13,9 @@ Attachment _$AttachmentFromJson(Map<String, dynamic> json) => Attachment(
       remoteUrl: json['remote_url'] == null
           ? null
           : Uri.parse(json['remote_url'] as String),
-      previewUrl: Uri.parse(json['preview_url'] as String),
+      previewUrl: json['preview_url'] == null
+          ? null
+          : Uri.parse(json['preview_url'] as String),
       textUrl: json['text_url'] == null
           ? null
           : Uri.parse(json['text_url'] as String),
@@ -27,7 +29,7 @@ Map<String, dynamic> _$AttachmentToJson(Attachment instance) =>
       'id': instance.id,
       'type': _$AttachmentTypeEnumMap[instance.type]!,
       'url': instance.url.toString(),
-      'preview_url': instance.previewUrl.toString(),
+      'preview_url': instance.previewUrl?.toString(),
       'remote_url': instance.remoteUrl?.toString(),
       'text_url': instance.textUrl?.toString(),
       'meta': instance.meta,


### PR DESCRIPTION
`previewUrl` seems to be null on audio media