### PR TITLE
Rename mastodon_dart to mastodon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Fix: export Meta and Option
 
 ## 1.0.3 (12/11/2022)
 
-- Feat: `Mastodon.websocketFactory` is now optional 
+- Feat: `Mastodon.websocketFactory` is now optional
 - Fix: move `Application.vapidKey` to `AuthenticatedApplication`
 
 ## 1.0.2 (12/9/2022)
@@ -57,7 +57,7 @@ Fix: export Meta and Option
 - remove business logic classes
 
 ## 0.3.2 (4/9/2020)
-- Fix [issue #30](https://github.com/lukepighetti/mastodon_dart/issues/30)
+- Fix [issue #30](https://github.com/lukepighetti/mastodon/issues/30)
 
 ## 0.3.0 (4/9/2020)
 - Add most missing data entities

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mastodon_dart
+# mastodon
 
 The unofficial Dart library for accessing the Mastodon API through REST or WebSockets.
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
-import 'package:mastodon_dart/mastodon_dart.dart';
-import 'package:mastodon_dart/src/exception.dart';
+import 'package:mastodon/mastodon.dart';
+import 'package:mastodon/src/exception.dart';
 
 /// This example shows how to use the Mastodon Dart library.
 ///

--- a/lib/mastodon.dart
+++ b/lib/mastodon.dart
@@ -1,4 +1,4 @@
-library mastodon_dart;
+library mastodon;
 
 export 'src/mastodon.dart';
 export 'src/models/account.dart';

--- a/lib/src/websockets/websockets.dart
+++ b/lib/src/websockets/websockets.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 
-import 'package:mastodon_dart/src/authentication.dart';
-import 'package:mastodon_dart/src/models/notification.dart';
-import 'package:mastodon_dart/src/models/status.dart';
+import 'package:mastodon/src/authentication.dart';
+import 'package:mastodon/src/models/notification.dart';
+import 'package:mastodon/src/models/status.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 mixin Websockets on Authentication {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
-name: mastodon_dart
+name: mastodon
 description: The unofficial Dart library for accessing the Mastodon API through REST or WebSockets
 version: 1.0.12
-homepage: https://github.com/lukepighetti/mastodon_dart
+homepage: https://github.com/lukepighetti/mastodon
 
 environment:
   sdk: ">=2.18.4 <3.0.0"


### PR DESCRIPTION
I randomly ran across https://github.com/mykdavies/Mastodon/issues/1. This updates the code so it can be published to https://pub.dev/packages/mastodon.