### PR TITLE
Use WSS on HTTPS instances

### DIFF
--- a/lib/src/websockets/websockets.dart
+++ b/lib/src/websockets/websockets.dart
@@ -8,7 +8,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 mixin Websockets on Authentication {
   WebSocketChannel _channel(String stream, {String? list, String? tag}) {
     final uri = baseUrl.replace(
-      scheme: "ws",
+      scheme: baseUrl.scheme == "https" ? "wss" : "ws",
       path: "/api/v1/streaming",
       queryParameters: {
         "access_token": token,


### PR DESCRIPTION
[Browsers require `wss://` connections instead of `ws://` on HTTPS websites.](https://web.dev/what-is-mixed-content/) Although it does not a problem in local development environments, `ws://` connections are blocked in web flutter applications being served in HTTPS.

Also, mastodon API docs use `wss://` over `ws://` [in the example](https://docs.joinmastodon.org/methods/streaming/#websocket).